### PR TITLE
Namespaced webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 **/debug
 **/debug.test
 
+gcp-trust-policy.json
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The `gtoken-webhook` can be configured to skip injection for all Pods in the spe
 
 ## `gtoken-webhook` deployment
 
+1. Create a new `gtoken` namespace:
+
+```sh
+kubectl create -f deployment/namespace.yaml
+```
+
+```
+
 1. To deploy the `gtoken-webhook` server, we need to create a webhook service and a deployment in our Kubernetes cluster. It’s pretty straightforward, except one thing, which is the server’s TLS configuration. If you’d care to examine the [deployment.yaml](https://github.com/doitintl/gtoken/blob/master/deployment/deployment.yaml) file, you’ll find that the certificate and corresponding private key files are read from command line arguments, and that the path to these files comes from a volume mount that points to a Kubernetes secret:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Injected AWS environment variables:
 
 The AWS SDK will automatically make the corresponding `AssumeRoleWithWebIdentity` calls to AWS STS on your behalf. It will handle in memory caching as well as refreshing credentials as needed.
 
+### skip injection
+
+The `gtoken-webhook` can be configured to skip injection for all Pods in the specific Namespace by adding the `admission.gtoken/ignore` label to the Namespace.
+
 ## `gtoken-webhook` deployment
 
 1. To deploy the `gtoken-webhook` server, we need to create a webhook service and a deployment in our Kubernetes cluster. It’s pretty straightforward, except one thing, which is the server’s TLS configuration. If you’d care to examine the [deployment.yaml](https://github.com/doitintl/gtoken/blob/master/deployment/deployment.yaml) file, you’ll find that the certificate and corresponding private key files are read from command line arguments, and that the path to these files comes from a volume mount that points to a Kubernetes secret:
@@ -80,10 +84,10 @@ Generating RSA private key, 2048 bit long modulus
 .........................+++
 ....................+++
 e is 65537 (0x10001)
-certificatesigningrequest.certificates.k8s.io/gtoken-webhook-svc.default created
+certificatesigningrequest.certificates.k8s.io/gtoken-webhook-svc.gtoken created
 NAME                         AGE   REQUESTOR              CONDITION
-gtoken-webhook-svc.default   1s    alexei@doit-intl.com   Pending
-certificatesigningrequest.certificates.k8s.io/gtoken-webhook-svc.default approved
+gtoken-webhook-svc.gtoken   1s    alexei@doit-intl.com   Pending
+certificatesigningrequest.certificates.k8s.io/gtoken-webhook-svc.gtoken approved
 secret/gtoken-webhook-certs configured
 ```
 
@@ -119,7 +123,7 @@ Now that our webhook server is running, it can accept requests from the `apiserv
 [...]
       service:
         name: gtoken-webhook-svc
-        namespace: default
+        namespace: gtoken
         path: "/pods"
       caBundle: ${CA_BUNDLE}
 [...]

--- a/deployment/clusterrolebinding.yaml
+++ b/deployment/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: gtoken-webhook-sa
-  namespace: default
+  namespace: gtoken
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gtoken-webhook-deployment
+  namespace: gtoken
   labels:
     app: gtoken-webhook
 spec:

--- a/deployment/mutatingwebhook.yaml
+++ b/deployment/mutatingwebhook.yaml
@@ -11,13 +11,21 @@ webhooks:
     clientConfig:
       service:
         name: gtoken-webhook-svc
-        namespace: default
+        namespace: gtoken
         path: "/pods"
       caBundle: ${CA_BUNDLE}
+    # select namespaces without the label "admission.gtoken/ignore"
+    namespaceSelector:
+      matchExpressions:
+        - key: admission.gtoken/ignore
+          operator: DoesNotExist
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods"]
+        scope: "Namespaced"
+    # ignore failures
+    failurePolicy: Ignore
 
 

--- a/deployment/namespace.yaml
+++ b/deployment/namespace.yaml
@@ -1,0 +1,7 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gtoken
+  labels:
+    app: gtoken-webhook
+    admission.gtoken/ignore: "true"

--- a/deployment/service-account.yaml
+++ b/deployment/service-account.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gtoken-webhook-sa
+  namespace: gtoken
   labels:
     app: gtoken-webhook

--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: gtoken-webhook-svc
+  namespace: gtoken
   labels:
     app: gtoken-webhook
 spec:

--- a/deployment/webhook-create-self-signed-cert.sh
+++ b/deployment/webhook-create-self-signed-cert.sh
@@ -46,7 +46,7 @@ done
 
 [ -z ${service} ] && service=gtoken-webhook-svc
 [ -z ${secret} ] && secret=gtoken-webhook-certs
-[ -z ${namespace} ] && namespace=default
+[ -z ${namespace} ] && namespace=gtoken
 
 if [ ! -x "$(command -v openssl)" ]; then
     echo "openssl not found"

--- a/deployment/webhook-create-signed-cert.sh
+++ b/deployment/webhook-create-signed-cert.sh
@@ -48,7 +48,7 @@ done
 
 [ -z ${service} ] && service=gtoken-webhook-svc
 [ -z ${secret} ] && secret=gtoken-webhook-certs
-[ -z ${namespace} ] && namespace=default
+[ -z ${namespace} ] && namespace=gtoken
 
 if [ ! -x "$(command -v openssl)" ]; then
     echo "openssl not found"


### PR DESCRIPTION
- webhook `scope=Namespaced`
- add the `admission.gtoken/ignore` label to any namespace to ignore all Pods (skip admission webhook)
- the `gtoken` webhook deployed into its own namespace, also named `gtoken`