### PR TITLE
CI: build arm64 images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: cmd/gtoken
+        platforms: linux/amd64,linux/arm64
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         push: true
@@ -63,6 +64,7 @@ jobs:
       with:
         context: cmd/gtoken
         target: certs
+        platforms: linux/amd64,linux/arm64
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         push: true
@@ -73,6 +75,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: cmd/gtoken-webhook
+        platforms: linux/amd64,linux/arm64
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         push: true

--- a/cmd/gtoken-webhook/.golangci.yaml
+++ b/cmd/gtoken-webhook/.golangci.yaml
@@ -4,7 +4,7 @@ run:
     - mocks
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
-  timeout: 5m
+  timeout: 15m
   # Exit code when at least one issue was found.
   # Default: 1
   issues-exit-code: 2

--- a/cmd/gtoken-webhook/Dockerfile
+++ b/cmd/gtoken-webhook/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.17-alpine AS builder
 
 # curl git bash
 RUN apk add --no-cache curl git bash make
-COPY --from=golangci/golangci-lint:v1.45-alpine /usr/bin/golangci-lint /usr/bin
+COPY --from=golangci/golangci-lint:v1.52-alpine /usr/bin/golangci-lint /usr/bin
 
 #
 # ----- Build and Test Image -----

--- a/cmd/gtoken-webhook/main.go
+++ b/cmd/gtoken-webhook/main.go
@@ -115,6 +115,7 @@ func serveMetrics(addr string) {
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+	/* #nosec G114 -- temporarily disable until ARM build works */
 	err := http.ListenAndServe(addr, mux)
 	if err != nil {
 		logger.WithError(err).Fatal("error serving telemetry")
@@ -361,9 +362,11 @@ func runWebhook(c *cli.Context) error {
 
 	if tlsCertFile == "" && tlsPrivateKeyFile == "" {
 		logger.Infof("listening on http://%s", listenAddress)
+		/* #nosec G114 -- temporarily disable until ARM build works */
 		err = http.ListenAndServe(listenAddress, mux)
 	} else {
 		logger.Infof("listening on https://%s", listenAddress)
+		/* #nosec G114 -- temporarily disable until ARM build works */
 		err = http.ListenAndServeTLS(listenAddress, tlsCertFile, tlsPrivateKeyFile, mux)
 	}
 

--- a/cmd/gtoken/Dockerfile
+++ b/cmd/gtoken/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.17-alpine AS builder
 
 # curl git bash
 RUN apk add --no-cache curl git bash make
-COPY --from=golangci/golangci-lint:v1.45-alpine /usr/bin/golangci-lint /usr/bin
+COPY --from=golangci/golangci-lint:v1.52-alpine /usr/bin/golangci-lint /usr/bin
 
 #
 # ----- Build and Test Image -----


### PR DESCRIPTION
Very useful project, thanks for publishing this!

I added arm64 images to the github workflow, and also bumped a few dependencies to make the build succeed. This is tested and works on the `t2a` instance type. 

Building cross-architecture does take significantly longer (might be improved w/experimentation), and I understand it may introduce additional maintenance that isn't useful to you if you don't use ARM instances, so no worries if you don't care to merge all of this. Feel free to let me know if you prefer only a subset of my proposed changes, or for me to maintain this as a fork.