### PR TITLE
Running gtoken as non-root user

### DIFF
--- a/cmd/gtoken-webhook/Dockerfile
+++ b/cmd/gtoken-webhook/Dockerfile
@@ -33,6 +33,8 @@ RUN make
 # ------ get latest CA certificates
 #
 FROM alpine:3.15 as certs
+RUN addgroup -S -g 9000 gtoken
+RUN adduser -S -u 9000 -g 9000 gtoken
 RUN apk --update add ca-certificates
 
 
@@ -43,8 +45,12 @@ FROM scratch
 
 # copy CA certificates
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-
+# copy /etc.passwd and /etc/group
+COPY --from=certs /etc/passwd /etc/passwd
+COPY --from=certs /etc/group /etc/group
 # this is the last commabd since it's never cached
 COPY --from=build /go/src/gtoken-webhook/.bin/github.com/doitintl/gtoken-webhook /gtoken-webhook
+
+USER 9000:9000
 
 ENTRYPOINT ["/gtoken-webhook"]

--- a/cmd/gtoken/Dockerfile
+++ b/cmd/gtoken/Dockerfile
@@ -34,6 +34,8 @@ RUN make
 # ------ get latest CA certificates
 #
 FROM alpine:3.15 as certs
+RUN addgroup -S -g 9000 gtoken
+RUN adduser -S -g 9000 -u 9000 gtoken
 RUN apk --update add ca-certificates
 # this is for debug only Alpine image
 COPY --from=build /go/src/gtoken/.bin/github.com/doitintl/gtoken /gtoken
@@ -46,8 +48,12 @@ FROM scratch
 
 # copy CA certificates
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-
+# copy /etc/passwd and /etc/group
+COPY --from=certs /etc/passwd /etc/passwd
+COPY --from=certs /etc/group /etc/group
 # this is the last commabd since it's never cached
 COPY --from=build /go/src/gtoken/.bin/github.com/doitintl/gtoken /gtoken
+
+USER 9000:9000
 
 ENTRYPOINT ["/gtoken"]


### PR DESCRIPTION
Fixes #36

Related error message

`Warning  Failed     14s (x5 over 63s)  kubelet            Error: container has runAsNonRoot and image will run as root (pod: "cert-manager-57795dbdd9-njd9b_cert-manager(a1b08a25-ed79-4641-9880-b83409533248)", container: generate-gcp-id-token)`