### PR TITLE
Dynamically reload the certificate when it changes 

### DIFF
--- a/cmd/gtoken-webhook/go.mod
+++ b/cmd/gtoken-webhook/go.mod
@@ -3,12 +3,14 @@ module github.com/doitintl/gtoken-webhook
 go 1.17
 
 require (
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/google/go-cmp v0.5.7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/slok/kubewebhook/v2 v2.0.0
 	github.com/urfave/cli v1.22.2
+	google.golang.org/appengine v1.6.7
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
@@ -45,7 +47,6 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	gomodules.xyz/jsonpatch/v3 v3.0.1 // indirect
 	gomodules.xyz/orderedmap v0.1.0 // indirect
-	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/cmd/gtoken-webhook/go.mod
+++ b/cmd/gtoken-webhook/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/slok/kubewebhook/v2 v2.0.0
 	github.com/urfave/cli v1.22.2
-	google.golang.org/appengine v1.6.7
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
@@ -47,6 +46,7 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	gomodules.xyz/jsonpatch/v3 v3.0.1 // indirect
 	gomodules.xyz/orderedmap v0.1.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/cmd/gtoken-webhook/main.go
+++ b/cmd/gtoken-webhook/main.go
@@ -121,7 +121,7 @@ func (cl *certLoader) watch(stopCh <-chan struct{}) {
 	for {
 		select {
 		case event := <-watcher.Events:
-			// Secret projected volumes often replace ..data directory, watch for create for it
+			// Secret projected volumes often replace ..data directory, watch for creation of it
 			if event.Op&fsnotify.Create != 0 && filepath.Base(event.Name) == "..data" {
 				logger.Warnf("cert/key file changed (%s), reloading...", event)
 				if err := cl.loadCert(); err != nil {

--- a/cmd/gtoken-webhook/main.go
+++ b/cmd/gtoken-webhook/main.go
@@ -113,7 +113,7 @@ func (cl *certLoader) watch(stopCh <-chan struct{}) {
 	// Watch directory where secret is mounted
 	certDir := filepath.Dir(cl.certPath)
 	if err := watcher.Add(certDir); err != nil {
-		logger.WithError(err).Fatalf("failed to add watcher for cert at path: %v", certDir)
+		logger.WithError(err).Fatalf("failed to add watcher for cert at path: %s", certDir)
 	}
 
 	logger.Infof("watching directory %s for TLS cert changes", certDir)

--- a/cmd/gtoken-webhook/main.go
+++ b/cmd/gtoken-webhook/main.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -70,66 +71,66 @@ const (
 	limitsMemory   = "50Mi"
 )
 
-type certReloader struct {
+type certLoader struct {
 	certPath string
 	keyPath  string
 	mu       sync.RWMutex
 	cert     *tls.Certificate
 }
 
-func newCertReloader(certPath, keyPath string) (*certReloader, error) {
-	cr := &certReloader{certPath: certPath, keyPath: keyPath}
-	if err := cr.reload(); err != nil {
+func newCertLoader(certPath, keyPath string) (*certLoader, error) {
+	cl := &certLoader{certPath: certPath, keyPath: keyPath}
+	if err := cl.loadCert(); err != nil {
 		return nil, err
 	}
-	return cr, nil
+	return cl, nil
 }
 
-func (cr *certReloader) reload() error {
-	cert, err := tls.LoadX509KeyPair(cr.certPath, cr.keyPath)
+func (cl *certLoader) loadCert() error {
+	cert, err := tls.LoadX509KeyPair(cl.certPath, cl.keyPath)
 	if err != nil {
 		return err
 	}
-	cr.mu.Lock()
-	cr.cert = &cert
-	cr.mu.Unlock()
-	logger.Infof("reloaded TLS certificate")
+	cl.mu.Lock()
+	cl.cert = &cert
+	cl.mu.Unlock()
 	return nil
 }
 
-func (cr *certReloader) getCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	cr.mu.RLock()
-	defer cr.mu.RUnlock()
-	return cr.cert, nil
+func (cl *certLoader) getCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cl.mu.RLock()
+	defer cl.mu.RUnlock()
+	return cl.cert, nil
 }
 
-func (cr *certReloader) watch(stopCh <-chan struct{}) {
+func (cl *certLoader) watch(stopCh <-chan struct{}) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer watcher.Close()
 
-	// Watch both cert and key
-	if err := watcher.Add(cr.certPath); err != nil {
-		log.Fatal(err)
+	// Watch directory where secret is mounted
+	certDir := filepath.Dir(cl.certPath)
+	if err := watcher.Add(certDir); err != nil {
+		logger.WithError(err).Fatalf("failed to add watcher for cert at path: %v", certDir)
 	}
-	if err := watcher.Add(cr.keyPath); err != nil {
-		log.Fatal(err)
-	}
+
+	logger.Infof("watching directory %s for TLS cert changes", certDir)
 
 	for {
 		select {
 		case event := <-watcher.Events:
-			// Secret projected volumes often replace the whole file → look for Write/Remove/Rename
-			if event.Op&(fsnotify.Write|fsnotify.Remove|fsnotify.Rename|fsnotify.Create) != 0 {
+			// Secret projected volumes often replace ..data directory, watch for create for it
+			if event.Op&fsnotify.Create != 0 && filepath.Base(event.Name) == "..data" {
 				logger.Warnf("cert/key file changed (%s), reloading...", event)
-				if err := cr.reload(); err != nil {
+				if err := cl.loadCert(); err != nil {
 					logger.WithError(err).Error("failed to reload cert")
 				}
+				logger.Infof("reloaded TLS certificate")
 			}
 		case err := <-watcher.Errors:
-			logger.WithError(err).Error("watcher error: %v", err)
+			logger.WithError(err).Error("watcher error")
 		case <-stopCh:
 			logger.Infof("stopping cert watcher")
 			return
@@ -421,6 +422,7 @@ func runWebhook(c *cli.Context) error {
 	listenAddress := c.String("listen-address")
 	tlsCertFile := c.String("tls-cert-file")
 	tlsPrivateKeyFile := c.String("tls-private-key-file")
+	watchCert := c.Bool("watch-cert")
 
 	if len(telemetryAddress) > 0 {
 		// Serving metrics without TLS on separated address
@@ -435,22 +437,27 @@ func runWebhook(c *cli.Context) error {
 	}
 	if tlsCertFile == "" && tlsPrivateKeyFile == "" {
 		logger.Infof("listening on http://%s", listenAddress)
-		err = srv.ListenAndServe()
+		if err := srv.ListenAndServe(); err != nil {
+			logger.WithError(err).Fatal("error serving webhook")
+		}
 	} else {
-		cr, err := newCertReloader(tlsCertFile, tlsPrivateKeyFile)
+		cl, err := newCertLoader(tlsCertFile, tlsPrivateKeyFile)
 		if err != nil {
 			logger.WithError(err).Fatal("failed to load TLS certs")
 		}
-
-		stopCh := make(chan struct{})
-		go cr.watch(stopCh) // background watcher
+		if watchCert {
+			stopCh := make(chan struct{})
+			go cl.watch(stopCh) // background watcher
+		}
 
 		srv.TLSConfig = &tls.Config{
-			GetCertificate: cr.getCertificate,
+			GetCertificate: cl.getCertificate,
 			MinVersion:     tls.VersionTLS12,
 		}
 		logger.Infof("listening on https://%s", listenAddress)
-		err = srv.ListenAndServeTLS("", "")
+		if err := srv.ListenAndServeTLS("", ""); err != nil {
+			logger.WithError(err).Fatal("error serving webhook")
+		}
 	}
 
 	if err != nil {
@@ -535,6 +542,10 @@ func main() {
 					Name:  "token-file",
 					Usage: "token file name",
 					Value: tokenFileName,
+				},
+				cli.BoolFlag{
+					Name:  "watch-cert",
+					Usage: "watch certificate and reload then when changes",
 				},
 			},
 			Usage:       "mutation admission webhook",

--- a/cmd/gtoken-webhook/main.go
+++ b/cmd/gtoken-webhook/main.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"net/http"
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -66,6 +69,73 @@ const (
 	limitsCPU      = "20m"
 	limitsMemory   = "50Mi"
 )
+
+type certReloader struct {
+	certPath string
+	keyPath  string
+	mu       sync.RWMutex
+	cert     *tls.Certificate
+}
+
+func newCertReloader(certPath, keyPath string) (*certReloader, error) {
+	cr := &certReloader{certPath: certPath, keyPath: keyPath}
+	if err := cr.reload(); err != nil {
+		return nil, err
+	}
+	return cr, nil
+}
+
+func (cr *certReloader) reload() error {
+	cert, err := tls.LoadX509KeyPair(cr.certPath, cr.keyPath)
+	if err != nil {
+		return err
+	}
+	cr.mu.Lock()
+	cr.cert = &cert
+	cr.mu.Unlock()
+	logger.Infof("reloaded TLS certificate")
+	return nil
+}
+
+func (cr *certReloader) getCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	return cr.cert, nil
+}
+
+func (cr *certReloader) watch(stopCh <-chan struct{}) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer watcher.Close()
+
+	// Watch both cert and key
+	if err := watcher.Add(cr.certPath); err != nil {
+		log.Fatal(err)
+	}
+	if err := watcher.Add(cr.keyPath); err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		select {
+		case event := <-watcher.Events:
+			// Secret projected volumes often replace the whole file → look for Write/Remove/Rename
+			if event.Op&(fsnotify.Write|fsnotify.Remove|fsnotify.Rename|fsnotify.Create) != 0 {
+				logger.Warnf("cert/key file changed (%s), reloading...", event)
+				if err := cr.reload(); err != nil {
+					logger.WithError(err).Error("failed to reload cert")
+				}
+			}
+		case err := <-watcher.Errors:
+			logger.WithError(err).Error("watcher error: %v", err)
+		case <-stopCh:
+			logger.Infof("stopping cert watcher")
+			return
+		}
+	}
+}
 
 type mutatingWebhook struct {
 	k8sClient  kubernetes.Interface
@@ -359,12 +429,28 @@ func runWebhook(c *cli.Context) error {
 		mux.Handle("/metrics", promhttp.Handler())
 	}
 
+	srv := &http.Server{
+		Addr:    listenAddress,
+		Handler: mux,
+	}
 	if tlsCertFile == "" && tlsPrivateKeyFile == "" {
 		logger.Infof("listening on http://%s", listenAddress)
-		err = http.ListenAndServe(listenAddress, mux)
+		err = srv.ListenAndServe()
 	} else {
+		cr, err := newCertReloader(tlsCertFile, tlsPrivateKeyFile)
+		if err != nil {
+			logger.WithError(err).Fatal("failed to load TLS certs")
+		}
+
+		stopCh := make(chan struct{})
+		go cr.watch(stopCh) // background watcher
+
+		srv.TLSConfig = &tls.Config{
+			GetCertificate: cr.getCertificate,
+			MinVersion:     tls.VersionTLS12,
+		}
 		logger.Infof("listening on https://%s", listenAddress)
-		err = http.ListenAndServeTLS(listenAddress, tlsCertFile, tlsPrivateKeyFile, mux)
+		err = srv.ListenAndServeTLS("", "")
 	}
 
 	if err != nil {


### PR DESCRIPTION
### Problem
We use dynamic certificates issued by letsencypt [cert-controller](https://github.com/cert-manager/cert-manager)
webhook just loads the certificate only when it starts, this change is to reload the certificate when it changes, this is behind a flag `cert-watch`, it should run as before without this flag